### PR TITLE
Fix marriages

### DIFF
--- a/src/events/advance_turn.js
+++ b/src/events/advance_turn.js
@@ -1,6 +1,8 @@
-export function advanceTurn({ turn, ...settlement }) {
+import Immutable from 'immutable';
+export function advanceTurn({ logs, turn, ...settlement }) {
   return {
     ...settlement,
-    turn: turn + 1
+    turn: turn + 1,
+    logs: logs.set(turn + 1, Immutable.List()),
   }
 }

--- a/src/events/advance_turn.spec.js
+++ b/src/events/advance_turn.spec.js
@@ -1,10 +1,16 @@
 import * as event from './advance_turn';
+import { make as makeSettlement } from '../models/settlement';
+import Immutable from 'immutable';
 
 describe('advanceTurn', () => {
   it('advances the turn of the settlement', () => {
-    let settlement = { turn: 0 };
-    let output = event.advanceTurn(settlement);
+    let settlement = {
+      ...makeSettlement({ people: 0 }),
+      turn: 0
+    };
+    let { turn, logs } = event.advanceTurn(settlement);
 
-    expect(output.turn).toEqual(1);
+    expect(turn).toEqual(1);
+    expect(Immutable.Map.isMap(logs)).toEqual(true);
   })
 })

--- a/src/events/population_ages.js
+++ b/src/events/population_ages.js
@@ -7,7 +7,7 @@ export function populationAges({ people, ...settlement }) {
 function age({ age, dead, ...settler }) {
   let nextAge = age + 1;
 
-  if (nextAge >= MAX_AGE || Math.random() < 0.1) {
+  if (nextAge >= MAX_AGE || Math.random() < 0.01) {
     return { age: nextAge, dead: true, ...settler }
   }
   return { ...settler, age: nextAge, dead: false }

--- a/src/events/population_ages.js
+++ b/src/events/population_ages.js
@@ -1,10 +1,7 @@
 import { MAX_AGE } from '../config';
 
 export function populationAges({ people, ...settlement }) {
-  people = people.
-    map(age)
-    .toList()
-  return { people, ...settlement };
+  return { people: people.map(age), ...settlement };
 }
 
 function age({ age, dead, ...settler }) {

--- a/src/events/population_ages.js
+++ b/src/events/population_ages.js
@@ -10,7 +10,7 @@ export function populationAges({ people, ...settlement }) {
 function age({ age, dead, ...settler }) {
   let nextAge = age + 1;
 
-  if (nextAge >= MAX_AGE || Math.random() < 0.01) {
+  if (nextAge >= MAX_AGE || Math.random() < 0.1) {
     return { age: nextAge, dead: true, ...settler }
   }
   return { ...settler, age: nextAge, dead: false }

--- a/src/events/population_ages.spec.js
+++ b/src/events/population_ages.spec.js
@@ -1,14 +1,13 @@
 import * as event from './population_ages';
+import { make as makeSettlement } from '../models/settlement';
 import Immutable from 'immutable';
 
 describe('populationAges', () => {
   it('makes the population age', () => {
-    let people = Immutable.List();
-    let person = { age: 10 };
-    people = people.push(person);
-    let settlement = { people: people };
+    let settlement = makeSettlement({ people: 1 });
+    let person = settlement.people.first();
     let output = event.populationAges(settlement);
 
-    expect(output.people.get(0).age).toEqual(11);
+    expect(output.people.first().age).toEqual(person.age + 1);
   })
 })

--- a/src/events/population_eats.spec.js
+++ b/src/events/population_eats.spec.js
@@ -1,10 +1,11 @@
 import * as event from './population_eats';
+import { make as makeSettlement } from '../models/settlement';
 import Immutable from 'immutable';
 
 describe('populationEats', () => {
   it('makes the population eat', () => {
-    let people = Immutable.List.of({}, {});
-    let settlement = { people: people, eatingRate: 12, food: 100 };
+    let settlement = makeSettlement({ people: 2 });
+    settlement = { ...settlement, eatingRate: 12, food: 100 };
     let output = event.populationEats(settlement);
 
     expect(output.food).toEqual(76);

--- a/src/events/population_marries.js
+++ b/src/events/population_marries.js
@@ -19,7 +19,11 @@ export function populationMarries(settlement) {
     return people.set(newlyWed.id, newlyWed)
   }, people);
 
-  return { ...settlement, people: newPeople, logs: logs.update(turn, currentEvents => currentEvents.concat(newLogs)) };
+  return {
+    ...settlement,
+    people: newPeople,
+    logs: logs.update(turn, currentEvents => currentEvents.concat(newLogs))
+  };
 }
 
 function singlesMap(people) {

--- a/src/events/population_marries.spec.js
+++ b/src/events/population_marries.spec.js
@@ -17,25 +17,34 @@ describe('populationMarries', () => {
 
     it('marries them', () => {
       let output = event.populationMarries(settlement);
+      let marriedPeople = output.people.filter(person => {
+        return person.marriedTo !== undefined
+      })
 
-      expect(output.people.get(2).marriedTo).toEqual(output.people.get(3).id)
+      expect(marriedPeople.count()).toEqual(2)
+      expect(marriedPeople.first().marriedTo).toEqual(marriedPeople.last().id)
+      expect(marriedPeople.last().marriedTo).toEqual(marriedPeople.first().id)
       expect(Immutable.Map.isMap(output.people)).toEqual(true);
     })
 
     it('does not marry the people that cannot have a partner', () => {
       let output = event.populationMarries(settlement);
+      let singlePeople = output.people.filter(person => {
+        return person.marriedTo === undefined
+      })
 
-      expect(output.people.get(1).marriedTo).toEqual(undefined)
+      expect(singlePeople.count()).toEqual(1)
+      expect(singlePeople.first().gender).toEqual('male')
     })
 
     it('adds some logs', () => {
       let output = event.populationMarries(settlement);
       let marriageLogs = output.logs.get(settlement.turn)
       .filter(event => {
-        return event.event === 'NEW_MARRIAGE'
+        return event.get('event') === 'NEW_MARRIAGE'
       })
 
-      expect(marriageLogs.toArray()).not.toEqual([]);
+      expect(marriageLogs.count()).not.toEqual(0);
     })
   })
 

--- a/src/events/population_marries.spec.js
+++ b/src/events/population_marries.spec.js
@@ -5,23 +5,27 @@ import Immutable from 'immutable';
 
 describe('populationMarries', () => {
   describe('when there are possible matches', () => {
-    let people = Immutable.List.of(
-      { ...makePerson(), gender: 'male' },
-      { ...makePerson(), gender: 'female' },
-      { ...makePerson(), gender: 'male' },
+    let settlement = makeSettlement({ people: 0 });
+    settlement.people = Immutable.Map.of(
+      1,
+      { ...makePerson(), id: 1, gender: 'male' },
+      2,
+      { ...makePerson(), id: 2, gender: 'female' },
+      3,
+      { ...makePerson(), id: 3, gender: 'male' },
     );
-    let settlement = { ...makeSettlement({ people: 1 }), people: people };
 
     it('marries them', () => {
       let output = event.populationMarries(settlement);
 
-      expect(output.people.get(2).marriedTo).toEqual(output.people.get(1).id)
+      expect(output.people.get(2).marriedTo).toEqual(output.people.get(3).id)
+      expect(Immutable.Map.isMap(output.people)).toEqual(true);
     })
 
     it('does not marry the people that cannot have a partner', () => {
       let output = event.populationMarries(settlement);
 
-      expect(output.people.get(0).marriedTo).toEqual(undefined)
+      expect(output.people.get(1).marriedTo).toEqual(undefined)
     })
 
     it('adds some logs', () => {
@@ -36,22 +40,24 @@ describe('populationMarries', () => {
   })
 
   describe('when some families already exist', () => {
-    let married1 = { ...makePerson(), gender: 'male' }
-    let married2 = { ...makePerson(), gender: 'female' }
-
-    let people = Immutable.List.of(
-      { ...makePerson(), gender: 'male' },
-      { ...makePerson(), gender: 'female' },
-      { ...makePerson(), gender: 'male' },
-      { ...married1, marriedTo: married2.id },
-      { ...married2, marriedTo: married1.id },
+    let settlement = makeSettlement({ people: 0 });
+    settlement.people = Immutable.Map.of(
+      1,
+      { ...makePerson(), id: 1, gender: 'male' },
+      2,
+      { ...makePerson(), id: 2, gender: 'female' },
+      3,
+      { ...makePerson(), id: 3, gender: 'male' },
+      4,
+      { ...makePerson(), id: 4, gender: 'female', marriedTo: 5 },
+      5,
+      { ...makePerson(), id: 5, gender: 'male', marriedTo: 4 },
     );
-    let settlement = { ...makeSettlement({ people: 1 }), people: people };
 
     it('does not remarry people with a partner', () => {
       let output = event.populationMarries(settlement);
 
-      expect(output.people.get(-1).marriedTo).toEqual(output.people.get(-2).id)
+      expect(output.people.get(4).marriedTo).toEqual(output.people.get(5).id)
     })
   })
 })

--- a/src/models/person.js
+++ b/src/models/person.js
@@ -3,7 +3,7 @@ import { composeName } from '../utils/name_generator'
 
 const GENDERS = ["male", "female"];
 
-let personId = 0;
+let personId = 1;
 export function make() {
   return {
     id: personId++,

--- a/src/models/settlement.js
+++ b/src/models/settlement.js
@@ -10,5 +10,9 @@ export function make({ people, ...settlement }) {
     settlers = settlers.set(settler.id, settler);
   }
 
-  return { ...settlement, people: settlers, turn: 0, logs: Immutable.Map() };
+  return { ...settlement,
+    people: settlers,
+    turn: 0,
+    logs: Immutable.Map.of(0, Immutable.List())
+  };
 }

--- a/src/models/settlement.js
+++ b/src/models/settlement.js
@@ -3,9 +3,12 @@ import { make as makeSettler, render as renderPeople } from './person';
 import { randomBetween } from '../utils/random';
 
 export function make({ people, ...settlement }) {
-  let settlers = Immutable.Range(0, people).
-    map(settler => makeSettler())
-    .toList();
+  let settlers = Immutable.Map();
+
+  for (let i = 0; i < people; i++) {
+    let settler = makeSettler();
+    settlers = settlers.set(settler.id, settler);
+  }
 
   return { ...settlement, people: settlers, turn: 0, logs: Immutable.Map() };
 }

--- a/src/models/settlement.spec.js
+++ b/src/models/settlement.spec.js
@@ -12,7 +12,7 @@ describe('Settlement', () => {
     it('sets some initial values', () => {
       let town = settlement.make({ people: 1 })
       expect(town.turn).toEqual(0)
-      expect(town.logs).toEqual(Immutable.Map())
+      expect(Immutable.Map.isMap(town.logs)).toEqual(true)
     })
   })
 })

--- a/src/models/settlement.spec.js
+++ b/src/models/settlement.spec.js
@@ -3,9 +3,10 @@ import Immutable from 'immutable';
 
 describe('Settlement', () => {
   describe('make', () => {
-    it('generates a list of settlers', () => {
+    it('generates a list of settlers in a map', () => {
       let town = settlement.make({ people: 1 })
       expect(town.people.count()).toEqual(1)
+      expect(Immutable.Map.isMap(town.people)).toEqual(true)
     })
 
     it('sets some initial values', () => {

--- a/src/services/gravedigger.js
+++ b/src/services/gravedigger.js
@@ -38,13 +38,16 @@ export class Gravedigger {
           }
         );
       } else {
-        alive = alive.push(person);
+        alive = alive.push(person.id);
       }
     });
 
     let newLogs = logs.set(turn, currentEvents);
+    people = people.filter(settler => {
+      return alive.includes(settler.id)
+    });
 
-    return {...this.settlement, people: alive, logs: newLogs };
+    return {...this.settlement, people, logs: newLogs };
   }
 
   deathMessage(person) {

--- a/src/services/gravedigger.spec.js
+++ b/src/services/gravedigger.spec.js
@@ -1,29 +1,32 @@
 import { Gravedigger } from './gravedigger';
+import { make as makePerson } from '../models/person';
+import { make as makeSettlement } from '../models/settlement';
 import Immutable from 'immutable';
 
 describe('Gravedigger', () => {
   describe('perform', () => {
     describe('when someone is dead', () => {
-      let people = Immutable.List();
-      let alive = {dead: false, age: 5, gender: 'male', name: 'Alive'}
-      let dead = {dead: true, age: 15, gender: 'female', name: 'Dead'}
-      people = people.push(alive)
-      people = people.push(dead)
-      let turn = 1;
-      let settlement = { people: people, turn: turn, logs: Immutable.Map() };
+      let settlement = makeSettlement({ people: 0 });
+      settlement.people = Immutable.Map.of(
+        1,
+        { ...makePerson(), id: 1, name: 'Alive' },
+        2,
+        { ...makePerson(), id: 2, name: 'Dead', dead: true },
+      );
       let worker = new Gravedigger(settlement);
 
       it('removes the dead people', () => {
         let newSettlement = worker.perform();
 
-        expect(newSettlement.people.toArray()).toEqual([alive]);
+        expect(newSettlement.people.count()).toEqual(1);
+        expect(newSettlement.people.first().id).toEqual(1);
       })
 
-      it('adds new logs', () => {
-        let newSettlement = worker.perform();
-
-        expect(newSettlement.logs.get(turn).count()).toEqual(1);
-      })
+      // it('adds new logs', () => {
+      //   let newSettlement = worker.perform();
+      //
+      //   expect(newSettlement.logs.get(settlement.turn).count()).toEqual(1);
+      // })
     })
   })
 })

--- a/src/services/gravedigger.spec.js
+++ b/src/services/gravedigger.spec.js
@@ -22,11 +22,11 @@ describe('Gravedigger', () => {
         expect(newSettlement.people.first().id).toEqual(1);
       })
 
-      // it('adds new logs', () => {
-      //   let newSettlement = worker.perform();
-      //
-      //   expect(newSettlement.logs.get(settlement.turn).count()).toEqual(1);
-      // })
+      it('adds new logs', () => {
+        let newSettlement = worker.perform();
+
+        expect(newSettlement.logs.get(settlement.turn).count()).toEqual(1);
+      })
     })
   })
 })

--- a/src/views/logger.js
+++ b/src/views/logger.js
@@ -15,8 +15,8 @@ function getMessage(event, settlement) {
 
   switch(event.event) {
   case 'NEW_MARRIAGE':
-    let person1 = settlement.people.find(v => v.id === event.peopleIds.get(0))
-    let person2 = settlement.people.find(v => v.id === event.peopleIds.get(1))
+    let person1 = settlement.people.get(event.peopleIds.get(0))
+    let person2 = settlement.people.get(event.peopleIds.get(1))
     return `${person1.name} (${person1.age}${person1.gender[0]}) and ${person2.name} (${person2.age}${person2.gender[0]}) got married`;
   }
 }

--- a/src/views/logger.js
+++ b/src/views/logger.js
@@ -5,7 +5,7 @@ export function render({ logs, turn, ...settlement }) {
   }
 
   let element = document.getElementById('log_details');
-  currentEvents.forEach(log => element.innerHTML += `<p>Year ${turn}: ${getMessage(log, settlement)}</p>`);
+  currentEvents.forEach(event => element.innerHTML += `<p>Year ${turn}: ${getMessage(event, settlement)}</p>`);
 }
 
 function getMessage(event, settlement) {
@@ -13,10 +13,10 @@ function getMessage(event, settlement) {
     return event.message
   }
 
-  switch(event.event) {
+  switch(event.get('event')) {
   case 'NEW_MARRIAGE':
-    let person1 = settlement.people.get(event.peopleIds.get(0))
-    let person2 = settlement.people.get(event.peopleIds.get(1))
+    let person1 = settlement.people.get(event.get('peopleIds').get(0))
+    let person2 = settlement.people.get(event.get('peopleIds').get(1))
     return `${person1.name} (${person1.age}${person1.gender[0]}) and ${person2.name} (${person2.age}${person2.gender[0]}) got married`;
   }
 }

--- a/src/views/settlers.js
+++ b/src/views/settlers.js
@@ -3,6 +3,7 @@ export function render({ people, ...settlement }) {
   let element = document.getElementById('settlers_details');
   element.innerHTML = '';
 
+  console.log(`======== TURN ${settlement.turn} ========`);
   people.forEach(settler => {
     content += `<li>${renderSettler(settler)}</li>`;
   });
@@ -11,5 +12,6 @@ export function render({ people, ...settlement }) {
 }
 
 function renderSettler({ name, age, gender, ...settler }) {
+  console.log(settler, name, age, gender);
   return `${name} (${age}${gender[0]})`;
 }

--- a/src/views/settlers.js
+++ b/src/views/settlers.js
@@ -4,14 +4,14 @@ export function render({ people, ...settlement }) {
   element.innerHTML = '';
 
   console.log(`======== TURN ${settlement.turn} ========`);
-  people.forEach(settler => {
-    content += `<li>${renderSettler(settler)}</li>`;
+  people.forEach((settler, id) => {
+    content += `<li>${renderSettler(settler, id)}</li>`;
   });
 
   element.innerHTML = `<ul>${content}</ul>`;
 }
 
-function renderSettler({ name, age, gender, ...settler }) {
-  console.log(settler, name, age, gender);
+function renderSettler({ name, age, gender, ...settler }, id) {
+  console.log(id, settler, name, age, gender);
   return `${name} (${age}${gender[0]})`;
 }


### PR DESCRIPTION
The marriages module had some bugs that caused data corruption. This PR fixes those errors by moving to a better functional solution.

Side effects of fixing these bugs:
- `settlement.people` is now a Map, so that it's easier to get a single settler knowing its ID: `settlement.people.get(id)`;
- Each turn, a new log list for the turn is added. This way we can always be sure that we're working with an existing list and we don't have to check every time whether the logs for the current turn exist or not.
