### PR TITLE
Improve the marriages module

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,4 @@
 export const MAX_AGE = 65;
+export const MINIMUM_AGE_TO_MARRY = 17;
+export const MAX_AGE_DIFFERENCE_TO_MARRY = 10;
+export const PROBABILITY_TO_MARRY = 0.8

--- a/src/events/population_marries.spec.js
+++ b/src/events/population_marries.spec.js
@@ -3,20 +3,42 @@ import { make as makePerson } from '../models/person';
 import { make as makeSettlement } from '../models/settlement';
 import Immutable from 'immutable';
 
+let randomness = () => 0.5;
+
 describe('populationMarries', () => {
+  describe('when singles are under age', () => {
+    let settlement = makeSettlement({ people: 0 });
+    settlement.people = Immutable.Map.of(
+      1,
+      { ...makePerson(), id: 1, age: 16, gender: 'male' },
+      2,
+      { ...makePerson(), id: 2, gender: 'female' },
+    );
+
+    it('does not marry them', () => {
+      let output = event.populationMarries(settlement, randomness);
+      let marriedPeople = output.people.filter(person => {
+        return person.marriedTo !== undefined
+      })
+
+      expect(marriedPeople.count()).toEqual(0)
+    })
+
+  })
+
   describe('when there are possible matches', () => {
     let settlement = makeSettlement({ people: 0 });
     settlement.people = Immutable.Map.of(
       1,
-      { ...makePerson(), id: 1, gender: 'male' },
+      { ...makePerson(), id: 1, age: 20, gender: 'male' },
       2,
-      { ...makePerson(), id: 2, gender: 'female' },
+      { ...makePerson(), id: 2, age: 20, gender: 'female' },
       3,
-      { ...makePerson(), id: 3, gender: 'male' },
+      { ...makePerson(), id: 3, age: 20, gender: 'male' },
     );
 
     it('marries them', () => {
-      let output = event.populationMarries(settlement);
+      let output = event.populationMarries(settlement, randomness);
       let marriedPeople = output.people.filter(person => {
         return person.marriedTo !== undefined
       })
@@ -28,7 +50,7 @@ describe('populationMarries', () => {
     })
 
     it('does not marry the people that cannot have a partner', () => {
-      let output = event.populationMarries(settlement);
+      let output = event.populationMarries(settlement, randomness);
       let singlePeople = output.people.filter(person => {
         return person.marriedTo === undefined
       })
@@ -38,7 +60,7 @@ describe('populationMarries', () => {
     })
 
     it('adds some logs', () => {
-      let output = event.populationMarries(settlement);
+      let output = event.populationMarries(settlement, randomness);
       let marriageLogs = output.logs.get(settlement.turn)
       .filter(event => {
         return event.get('event') === 'NEW_MARRIAGE'
@@ -52,19 +74,19 @@ describe('populationMarries', () => {
     let settlement = makeSettlement({ people: 0 });
     settlement.people = Immutable.Map.of(
       1,
-      { ...makePerson(), id: 1, gender: 'male' },
+      { ...makePerson(), id: 1, age: 20, gender: 'male' },
       2,
-      { ...makePerson(), id: 2, gender: 'female' },
+      { ...makePerson(), id: 2, age: 20, gender: 'female' },
       3,
-      { ...makePerson(), id: 3, gender: 'male' },
+      { ...makePerson(), id: 3, age: 20, gender: 'male' },
       4,
-      { ...makePerson(), id: 4, gender: 'female', marriedTo: 5 },
+      { ...makePerson(), id: 4, age: 20, gender: 'female', marriedTo: 5 },
       5,
-      { ...makePerson(), id: 5, gender: 'male', marriedTo: 4 },
+      { ...makePerson(), id: 5, age: 20, gender: 'male', marriedTo: 4 },
     );
 
     it('does not remarry people with a partner', () => {
-      let output = event.populationMarries(settlement);
+      let output = event.populationMarries(settlement, randomness);
 
       expect(output.people.get(4).marriedTo).toEqual(output.people.get(5).id)
     })


### PR DESCRIPTION
Improves the marriages module with:
- Chance to marry (80%)
- Marry the one that has a closer age to the current villager. Imagine we have a 20m, 30f, 40m, 50f village and 30f and 40m marry. Then 20m and 50f would be forced to marry. With this PR we will have 20m-30f and 40m-50f marriages.
- Limit the age difference between newly weds to 10 years.
